### PR TITLE
Fix plot image export dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit
 pandas
 plotly
+kaleido
 openpyxl


### PR DESCRIPTION
## Summary
- include `kaleido` so Plotly can export figures

## Testing
- `python -m py_compile price_dash.py user_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6844e7153368833096ae4d4dfec4d16c